### PR TITLE
Enable whitespace linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - prealloc
     - revive
     - unconvert
+    - whitespace
 linters-settings:
   depguard:
     rules:


### PR DESCRIPTION
Whitespace linter removes unnecessary "\n".
For example at the start and on the end of function.